### PR TITLE
Consumer upsert should point to '/consumers', not '/consumers/{user}'

### DIFF
--- a/src/Kong/Apis/Consumer.php
+++ b/src/Kong/Apis/Consumer.php
@@ -57,14 +57,13 @@ class Consumer extends AbstractApi
     /**
      * Update or Create a Consumer
      *
-     * @param string $user
      * @param array $options
      * @return \stdClass
      */
-    public function upsert ($user, array $options = [])
+    public function upsert (array $options = [])
     {
         $body   = $this->createRequestBody($options);
-        return $this->call('put', "consumers/{$user}", [], $body);
+        return $this->call('put', "consumers", [], $body);
     }
 
     /**


### PR DESCRIPTION
https://getkong.org/docs/0.9.x/admin-api/#update-or-create-consumer

This behaviour has been the same going back to at least 0.4