### PR TITLE
Add ability to add additional headers during a request.

### DIFF
--- a/src/Kong/Apis/AbstractApi.php
+++ b/src/Kong/Apis/AbstractApi.php
@@ -59,15 +59,23 @@ abstract class AbstractApi
     protected $url;
 
     /**
+     * Global request headers
+     *
+     * @var array
+     */
+    protected $request_headers;
+
+    /**
      * Class Constructor
      *
      * @param string $url
      * @param integer $port
      */
-    public function __construct($url, $port)
+    public function __construct($url, $port, $headers)
     {
         $this->port    = $port;
         $this->url    = $url;
+        $this->request_headers = $headers;
     }
 
     /**
@@ -87,6 +95,7 @@ abstract class AbstractApi
         $verb        = strtoupper($verb);
         $api        = "{$this->url}:{$this->port}/{$uri}";
         $headers    = array_merge(
+            $this->request_headers,
             $headers,
             ['Content-Type: application/json']
         );

--- a/src/Kong/Apis/AbstractApi.php
+++ b/src/Kong/Apis/AbstractApi.php
@@ -63,7 +63,7 @@ abstract class AbstractApi
      *
      * @var array
      */
-    protected $request_headers;
+    protected $request_headers = ['Content-Type: application/json'];
 
     /**
      * Class Constructor
@@ -71,11 +71,10 @@ abstract class AbstractApi
      * @param string $url
      * @param integer $port
      */
-    public function __construct($url, $port, $headers)
+    public function __construct($url, $port)
     {
         $this->port    = $port;
         $this->url    = $url;
-        $this->request_headers = $headers;
     }
 
     /**
@@ -95,9 +94,8 @@ abstract class AbstractApi
         $verb        = strtoupper($verb);
         $api        = "{$this->url}:{$this->port}/{$uri}";
         $headers    = array_merge(
-            $this->request_headers,
             $headers,
-            ['Content-Type: application/json']
+            $this->request_headers
         );
 
         try {
@@ -182,6 +180,21 @@ abstract class AbstractApi
     public function getRawBody()
     {
         return $this->rawBody;
+    }
+
+    /**
+     * Set headers to be used during the request
+     *
+     * @param array $headers
+     * @param bool  $merge
+     *
+     * @return $this
+     */
+    public function setHeaders(array $headers, $merge = true)
+    {
+        $this->request_headers = $merge ? array_merge($this->request_headers, $headers) : $headers;
+
+        return $this;
     }
 
     /**

--- a/src/Kong/Kong.php
+++ b/src/Kong/Kong.php
@@ -25,6 +25,13 @@ class Kong
     protected $url;
 
     /**
+     * Array of headers that should be passed to all requests
+     *
+     * @var array
+     */
+    protected $headers;
+    
+    /**
      * Class Constructor
      *
      * @throws \Ignittion\Kong\Exceptions\InvalidUrlException when non-RFC
@@ -32,8 +39,9 @@ class Kong
      *
      * @param string $url
      * @param integer $port
+     * @param array $headers
      */
-    public function __construct($url, $port = 8001)
+    public function __construct($url, $port = 8001, $headers = [])
     {
         if (filter_var($url, FILTER_VALIDATE_URL) === false) {
             throw new InvalidUrlException($url);
@@ -41,6 +49,7 @@ class Kong
 
         $this->port = $port;
         $this->url  = rtrim($url, '/');
+        $this->headers = $headers;
     }
 
     /**
@@ -50,7 +59,7 @@ class Kong
      */
     public function api()
     {
-        return new Api($this->url, $this->port);
+        return new Api($this->url, $this->port, $this->headers);
     }
 
     /**
@@ -60,7 +69,7 @@ class Kong
      */
     public function consumer()
     {
-        return new Consumer($this->url, $this->port);
+        return new Consumer($this->url, $this->port, $this->headers);
     }
 
     /**
@@ -70,7 +79,7 @@ class Kong
      */
     public function node()
     {
-        return new Node($this->url, $this->port);
+        return new Node($this->url, $this->port, $this->headers);
     }
 
     /**
@@ -80,6 +89,6 @@ class Kong
      */
     public function plugin()
     {
-        return new Plugin($this->url, $this->port);
+        return new Plugin($this->url, $this->port, $this->headers);
     }
 }

--- a/src/Kong/Kong.php
+++ b/src/Kong/Kong.php
@@ -23,7 +23,7 @@ class Kong
      * @var string
      */
     protected $url;
- 
+
     /**
      * Class Constructor
      *

--- a/src/Kong/Kong.php
+++ b/src/Kong/Kong.php
@@ -23,13 +23,6 @@ class Kong
      * @var string
      */
     protected $url;
-
-    /**
-     * Array of headers that should be passed to all requests
-     *
-     * @var array
-     */
-    protected $headers;
     
     /**
      * Class Constructor
@@ -39,9 +32,8 @@ class Kong
      *
      * @param string $url
      * @param integer $port
-     * @param array $headers
      */
-    public function __construct($url, $port = 8001, $headers = [])
+    public function __construct($url, $port = 8001)
     {
         if (filter_var($url, FILTER_VALIDATE_URL) === false) {
             throw new InvalidUrlException($url);
@@ -49,7 +41,6 @@ class Kong
 
         $this->port = $port;
         $this->url  = rtrim($url, '/');
-        $this->headers = $headers;
     }
 
     /**
@@ -59,7 +50,7 @@ class Kong
      */
     public function api()
     {
-        return new Api($this->url, $this->port, $this->headers);
+        return new Api($this->url, $this->port);
     }
 
     /**
@@ -69,7 +60,7 @@ class Kong
      */
     public function consumer()
     {
-        return new Consumer($this->url, $this->port, $this->headers);
+        return new Consumer($this->url, $this->port);
     }
 
     /**
@@ -79,7 +70,7 @@ class Kong
      */
     public function node()
     {
-        return new Node($this->url, $this->port, $this->headers);
+        return new Node($this->url, $this->port);
     }
 
     /**
@@ -89,6 +80,6 @@ class Kong
      */
     public function plugin()
     {
-        return new Plugin($this->url, $this->port, $this->headers);
+        return new Plugin($this->url, $this->port);
     }
 }

--- a/src/Kong/Kong.php
+++ b/src/Kong/Kong.php
@@ -23,7 +23,7 @@ class Kong
      * @var string
      */
     protected $url;
-    
+ 
     /**
      * Class Constructor
      *


### PR DESCRIPTION
This PR adds the functionality to add headers to a request. I use the Kong "Key Authentication" plugin to secure the Admin API without needing to expose port 8001, having the ability to specify additional headers during the requests will accomodate most authentication methods that look for specific headers.

```
$kong = new Kong(host, port);
$consumer = $kong->consumer();
$consumer->setHeaders(['X-EXAMPLE-HEADER' => 'foobar']);
$consumer->create(['custom_id' => 666, 'username' => 'devil']);
```

